### PR TITLE
Making sure that no two quotes can be selected at once

### DIFF
--- a/welove_cos/quotes/models.py
+++ b/welove_cos/quotes/models.py
@@ -18,6 +18,13 @@ class Quote(models.Model):
     source = models.ForeignKey(Source, on_delete=models.CASCADE, null=True)
     popularity = models.IntegerField(default=0)
 
+    def save(self, *args, **kwargs):
+        # Only one Quote instance can be 'selected'
+        if self.selected:
+            Quote.objects.filter(selected=True).update(selected=False)
+
+        super().save(*args, **kwargs)
+
     def __str__(self):
         returned_str = "A quote from %s" % (self.source.name)
         return returned_str

--- a/welove_cos/quotes/test_models.py
+++ b/welove_cos/quotes/test_models.py
@@ -50,6 +50,32 @@ class QuoteTest(QuoteReadyTestCase):
             "A quote from {}".format(quote.source.name)
         )
 
+    def test_save_method(self):
+        quote_one = self.create_quote(text="A rock band rocks")
+        quote_two = self.create_quote(text="A pop band pops")
+
+        quote_one.quote_text = "This rock band rocks"
+        quote_one.save()
+
+        self.assertEqual(
+            Quote.objects.filter(quote_text="This rock band rocks")[0],
+            quote_one
+        )
+
+        quote_one.selected = True
+        quote_one.save()
+
+        selected_quotes = Quote.objects.filter(selected=True)
+        self.assertEqual(len(selected_quotes), 1)
+        self.assertEqual(selected_quotes[0], quote_one)
+
+        quote_two.selected = True
+        quote_two.save()
+
+        selected_quotes = Quote.objects.filter(selected=True)
+        self.assertEqual(len(selected_quotes), 1)
+        self.assertEqual(selected_quotes[0], quote_two)
+
 
 class SourceTest(QuoteReadyTestCase):
     def test_source_fields(self):


### PR DESCRIPTION
Addressing issue #22.
Modified the save method of quote to make sure that not two quotes can be selected at once and adding corresponding test.